### PR TITLE
QCCR1L68982_Jira_Integration_fail_to_synchronize

### DIFF
--- a/src/com/ppm/integration/agilesdk/connector/jira/util/dm/AgileEntityUtils.java
+++ b/src/com/ppm/integration/agilesdk/connector/jira/util/dm/AgileEntityUtils.java
@@ -97,6 +97,10 @@ public class AgileEntityUtils {
 						String ids = "";
 						String names = "";
 						for (int i = 0; i < fieldList.length(); i++) {
+						    //Fix QCCR1L68982,if an element in the fieldlist which is NOT a JSONObject,it will be ignored 
+							if(!(fieldList.get(i) instanceof JSONObject)) {				    					    	
+				    			continue;
+				    		}
 							JSONObject field = (JSONObject) fieldList.get(i);
 							String id = field.has("id") ? field.getString("id") : null;
 							String value = field.has("value") ? field.getString("value") : null;


### PR DESCRIPTION
PPM can't support this scenario:

Added the value into the "labels" field  in jira side, such as PPM,PPM1

PPM treats it as String

then sync up the project to ppm side,it failed.

 the stack trace is as blow

java.lang.ClassCastException: java.lang.String cannot be cast to org.json.JSONObject at com.ppm.integration.agilesdk.connector.jira.util.dm.AgileEntityUtils.getAgileEntityFromIssueJSon(AgileEntityUtils.java:100)
	