### PR TITLE
defect#1716206 Error when retrieving Issues Type fields for JIRA project

### DIFF
--- a/src/com/ppm/integration/agilesdk/connector/jira/service/JIRAService.java
+++ b/src/com/ppm/integration/agilesdk/connector/jira/service/JIRAService.java
@@ -1700,7 +1700,7 @@ public class JIRAService {
                                         JIRAFieldInfo fieldInfo = JIRAFieldInfo.fromJSONObject(field, fieldKey);
                                         jiraFieldsInfo.put(fieldInfo.getKey(), fieldInfo);
                                     } catch (Exception e) {
-                                    logger.error("Couldn't read fieldInfo information for the following Field JSON, Skipping field:" + field.toString());
+                                        logger.error("Couldn't read fieldInfo information for the following Field JSON, Skipping field:" + field.toString());
                                         continue;
                                     }
                                 }

--- a/src/com/ppm/integration/agilesdk/connector/jira/service/JIRAService.java
+++ b/src/com/ppm/integration/agilesdk/connector/jira/service/JIRAService.java
@@ -1692,15 +1692,17 @@ public class JIRAService {
                         // The issue type is always uniquely filtered so there should be only one record at most
                         JSONObject fields = issueTypes.getJSONObject(0).getJSONObject("fields");
 
-                        for (String fieldKey : JSONObject.getNames(fields)) {
-                            if (!jiraFieldsInfo.containsKey(fieldKey)) {
-                                JSONObject field = fields.getJSONObject(fieldKey);
-                                try {
-                                    JIRAFieldInfo fieldInfo = JIRAFieldInfo.fromJSONObject(field, fieldKey);
-                                    jiraFieldsInfo.put(fieldInfo.getKey(), fieldInfo);
-                                } catch (Exception e) {
+                        if (fields != null && !fields.isEmpty()) {
+                            for (String fieldKey : JSONObject.getNames(fields)) {
+                                if (!jiraFieldsInfo.containsKey(fieldKey)) {
+                                    JSONObject field = fields.getJSONObject(fieldKey);
+                                    try {
+                                        JIRAFieldInfo fieldInfo = JIRAFieldInfo.fromJSONObject(field, fieldKey);
+                                        jiraFieldsInfo.put(fieldInfo.getKey(), fieldInfo);
+                                    } catch (Exception e) {
                                     logger.error("Couldn't read fieldInfo information for the following Field JSON, Skipping field:" + field.toString());
-                                    continue;
+                                        continue;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Customer configured the * for jira projects, so PPM retrieved the fields of issue type for all jira projects.
But one jira project only returned an empty fields for the issue type from customer jira server. 
This caused the sync job fails due to NPE, though this jira project is not integrated with PPM request.

add a check whether the fields of the issue type are available